### PR TITLE
Remove gather_facts setting from playbook.

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -19,7 +19,6 @@
   hosts: all
   become: yes
   tags: common
-  gather_facts: no
   remote_user: "{{ ansible_remote_user }}"
   roles:
   - common
@@ -28,7 +27,6 @@
   hosts: sympa
   become: yes
   tags: sympa
-  gather_facts: no
   remote_user: "{{ ansible_remote_user }}"
   roles:
   - sympa


### PR DESCRIPTION
Unless there is a good reason for this setting, we should stick to
Ansible's defaults.