### PR TITLE
Replaced include_tasks with import_tasks.

### DIFF
--- a/roles/sympa/tasks/main.yml
+++ b/roles/sympa/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install prerequisites for Sympa
   tags: sympa_prereq
-  include_tasks: sympa_prereq.yml
+  import_tasks: sympa_prereq.yml
   
 - name: Getting source folder name
   tags: always
@@ -28,19 +28,19 @@
 
 - name: Configure postfix and mail aliases
   tags: sympa_mail
-  include_tasks: sympa_mail.yml
+  import_tasks: sympa_mail.yml
 
 - name: Configure Apache
   tags: sympa_web
-  include_tasks: sympa_web.yml
+  import_tasks: sympa_web.yml
 
 - name: Install and configure database
   tags: sympa_db
-  include_tasks: sympa_db.yml
+  import_tasks: sympa_db.yml
 
 - name: Enable Sympa startup
   tags: sympa_startup
-  include_tasks: sympa_startup.yml
+  import_tasks: sympa_startup.yml
 
 ## include_vars merges all variables in a single hash
 ## therefore each robot YML file needs to have a different hash key

--- a/roles/sympa/tasks/sympa_install/get_sources.yml
+++ b/roles/sympa/tasks/sympa_install/get_sources.yml
@@ -8,9 +8,9 @@
   with_items: ["{{ sympa_install_prefix }}", "{{ sympa_install_prefix }}/src"]
 
 - name: Include retrieving sources from tar.gz task if needed
-  include_tasks: get_sources_from_targz.yml
+  import_tasks: get_sources_from_targz.yml
   when: not sympa_install_from_repository
 
 - name: Include retrieving sources from repository if needed.
-  include_tasks: get_sources_from_repo.yml
+  import_tasks: get_sources_from_repo.yml
   when: sympa_install_from_repository


### PR DESCRIPTION
As mentionned in https://serverfault.com/questions/875247/whats-the-difference-between-include-tasks-and-import-tasks:
    - you should use import when you deal with logical "units". For example, separate long list of tasks into subtask files
    - you would use include to deal with different workflows and take decisions based on some dynamically gathered facts:

Advantages of this approach:
- tags defined at the import_tasks level are inherited by the imported task. For instance you can now run: ansible-playbook -i environment/local/inventory -t sympa_mail site.yml
- ansible-playbook execution seems faster, as mentionned in https://github.com/ansible/ansible/issues/30441