### PR TITLE
Fix mismatch of location of list aliases file.

### DIFF
--- a/roles/sympa/defaults/main.yml
+++ b/roles/sympa/defaults/main.yml
@@ -54,3 +54,5 @@ sympa_outgoing_server: "{{ sympa_incoming_smtp }}"
 sympa_db_type: mysql
 sympa_db_app_user: sympa
 sympa_language: "en_US"
+sympa_global_alias_file: "/etc/mail/sympa_global_aliases"
+sympa_list_alias_file: "/etc/mail/sympa_list_aliases"

--- a/roles/sympa/tasks/sympa_install/deploy.yml
+++ b/roles/sympa/tasks/sympa_install/deploy.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Install Sympa [1/3: configure]"
-  shell: ./configure --prefix={{ sympa_install_prefix }} --with-lockdir=/var/lock --without-initdir --with-unitsdir=/lib/systemd/system
+  shell: ./configure --prefix={{ sympa_install_prefix }} --with-lockdir=/var/lock --without-initdir --with-unitsdir=/lib/systemd/system --with-aliases_file={{ sympa_list_alias_file }}
   args:
     chdir: "{{ sympa_install_prefix }}/src/{{ source_dir }}"
     executable: /bin/bash

--- a/roles/sympa/tasks/sympa_mail.yml
+++ b/roles/sympa/tasks/sympa_mail.yml
@@ -13,13 +13,13 @@
 - name: Create required /etc/mail/ directory    
   file: dest=/etc/mail state=directory mode=755 owner=sympa group=sympa
 
-- name: Check if /etc/mail/sympa_list_aliases file exists
+- name: Check list alias file exists
   stat:
-    path: /etc/mail/sympa_list_aliases
+    path: "{{ sympa_list_alias_file }}"
   register: sympa_list_aliases_check 
 
 - name: Install Sympa default list mail aliases
-  template: src=postfix/sympa_list_aliases.j2 dest=/etc/mail/sympa_list_aliases owner=sympa group=sympa mode=0664 force=no
+  template: src=postfix/sympa_list_aliases.j2 dest="{{ sympa_list_alias_file}}" owner=sympa group=sympa mode=0664 force=no
   when: sympa_list_aliases_check.stat.exists == False
   notify: update postfix aliases database
 
@@ -34,8 +34,8 @@
 - name: Creating sympa global alias
   template:
     src: postfix/sympa_global_aliases.j2
-    dest: /etc/mail/sympa_global_aliases
+    dest: "{{ sympa_global_alias_file }}"
   notify: update postfix aliases database
 
 - name: Compile bounce alias
-  shell: postalias /etc/mail/sympa_global_aliases
+  shell: postalias {{ sympa_global_alias_file }}

--- a/roles/sympa/templates/postfix/main.cf.j2
+++ b/roles/sympa/templates/postfix/main.cf.j2
@@ -29,8 +29,8 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
 myhostname = {{ sympa_mail_hostname }}
-alias_maps = hash:/etc/aliases hash:/etc/mail/sympa_list_aliases hash:/etc/mail/sympa_global_aliases
-alias_database = hash:/etc/aliases hash:/etc/mail/sympa_list_aliases hash:/etc/mail/sympa_global_aliases
+alias_maps = hash:/etc/aliases hash:{{ sympa_list_alias_file }} hash:{{ sympa_global_alias_file }}
+alias_database = hash:/etc/aliases hash:{{ sympa_list_alias_file }} hash:{{ sympa_global_alias_file }}
 mydestination = $myhostname, local-sympa, localhost.localdomain, localhost 
 {% if sympa_force_smtp_route %}
 relayhost = {{ sympa_outgoing_server }}


### PR DESCRIPTION
Sympa used /etc/sympa_aliases and Postfix used /etc/sympa_list_aliases.
Also added variables for the location of the global and list aliases.

@dverdin Your refactoring branch is supposed to have a better solution, but this is a bug really affecting the mail flow and needed to be fix. 