### PR TITLE
Remove mail related task from MySQL tasks.

### DIFF
--- a/roles/sympa/tasks/sympa_db_mysql.yml
+++ b/roles/sympa/tasks/sympa_db_mysql.yml
@@ -56,9 +56,3 @@
     - 127.0.0.1
     - ::1
     - localhost
-
-- name: Create required /etc/mail/ directory    
-  file:
-    dest: /etc/mail
-    state: directory
-    mode: 755


### PR DESCRIPTION
This task is in the wrong place, even if that is really necessary. Also it wouldn't be executed when you choose PostgreSQL database type. 