### PR TITLE
Remove roles_path from ansible configuration 

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,4 +3,3 @@
 pipelining=True
 nocows=1
 hash_behaviour=merge
-roles_path = ~/git/roles


### PR DESCRIPTION
As it refers to a directory outside of the repository.