### PR TITLE
Updated apache 2.4 config

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -116,6 +116,6 @@
 - include: "{{ inventory_dir }}/tasks/apache.yml"
 
 - name: Check created config
-  shell: "apache2ctl configtest"
+  command: "apache2ctl configtest"
   notify: Restart Apache
   changed_when: true

--- a/roles/sympa/handlers/main.yml
+++ b/roles/sympa/handlers/main.yml
@@ -12,8 +12,5 @@
 - name: restart rsyslog
   service: name=rsyslog state=restarted
 
-- name: restart mysql
-  service: name=mysql state=restarted
-
 - name: restart apache
   service: name=apache2 state=restarted

--- a/roles/sympa/handlers/main.yml
+++ b/roles/sympa/handlers/main.yml
@@ -11,3 +11,12 @@
 
 - name: restart rsyslog
   service: name=rsyslog state=restarted
+
+- name: restart mysql
+  service: name=mysql state=restarted
+
+- name: restart apache
+  service: name=apache2 state=restarted
+
+- name: restart systemd
+  shell: "systemctl --system daemon-reload"

--- a/roles/sympa/handlers/main.yml
+++ b/roles/sympa/handlers/main.yml
@@ -17,6 +17,3 @@
 
 - name: restart apache
   service: name=apache2 state=restarted
-
-- name: restart systemd
-  shell: "systemctl --system daemon-reload"

--- a/roles/sympa/handlers/main.yml
+++ b/roles/sympa/handlers/main.yml
@@ -11,6 +11,3 @@
 
 - name: restart rsyslog
   service: name=rsyslog state=restarted
-
-- name: restart apache
-  service: name=apache2 state=restarted

--- a/roles/sympa/tasks/main.yml
+++ b/roles/sympa/tasks/main.yml
@@ -48,6 +48,10 @@
   tags: sympa_prereq
   import_tasks: sympa_prereq.yml
   
+- name: Install and configure database
+  tags: sympa_db
+  import_tasks: "sympa_db_{{ sympa.db.type | lower }}.yml"
+
 - name: Getting source folder name
   tags: always
   include_vars: source_dir_repo.yml
@@ -77,10 +81,6 @@
 - name: Configure Apache
   tags: sympa_web
   import_tasks: sympa_web.yml
-
-- name: Install and configure database
-  tags: sympa_db
-  import_tasks: "sympa_db_{{ sympa.db.type | lower }}.yml"
 
 - name: Enable Sympa startup
   tags: sympa_startup

--- a/roles/sympa/tasks/sympa_install/deploy.yml
+++ b/roles/sympa/tasks/sympa_install/deploy.yml
@@ -1,19 +1,19 @@
 ---
 
 - name: "Install Sympa [1/3: configure]"
-  shell: ./configure --prefix={{ install_prefix }}/{{ sympa.install_dir_name }} --with-lockdir=/var/lock --without-initdir --with-unitsdir=/lib/systemd/system --with-spooldir=/var/spool/sympa --with-expldir={{ sympa.lists_path }}
+  command: ./configure --prefix={{ install_prefix }}/{{ sympa.install_dir_name }} --with-lockdir=/var/lock --without-initdir --with-unitsdir=/lib/systemd/system --with-spooldir=/var/spool/sympa --with-expldir={{ sympa.lists_path }}
   args:
     chdir: "{{ install_prefix }}/{{ sympa.install_dir_name }}/src/{{ source_dir }}"
     executable: /bin/bash
 
 - name: "Install Sympa [2/3: make]"
-  shell: make
+  command: make
   args:
     chdir: "{{ install_prefix }}/{{ sympa.install_dir_name }}/src/{{ source_dir }}"
     executable: /bin/bash
 
 - name: "Install Sympa [3/3: make install]"
-  shell: make install
+  command: make install
   args:
     chdir: "{{ install_prefix }}/{{ sympa.install_dir_name }}/src/{{ source_dir }}"
     executable: /bin/bash

--- a/roles/sympa/tasks/sympa_install/get_sources_from_repo.yml
+++ b/roles/sympa/tasks/sympa_install/get_sources_from_repo.yml
@@ -13,7 +13,7 @@
     version: "{{ sympa.repository_version }}"
 
 - name: Prepare configure
-  shell: autoreconf -i
+  command: autoreconf -i
   args:
     chdir: "{{ install_prefix }}/{{ sympa.install_dir_name }}/src/{{ source_dir }}"
     executable: /bin/bash

--- a/roles/sympa/tasks/sympa_mail.yml
+++ b/roles/sympa/tasks/sympa_mail.yml
@@ -27,7 +27,7 @@
     - "{{ sympa.mail.alias_file }}.db"
 
 - name: Compiling sympa_aliases
-  shell: "postmap {{ sympa.mail.alias_directory }}/{{ sympa.mail.alias_file }}"
+  command: "postmap {{ sympa.mail.alias_directory }}/{{ sympa.mail.alias_file }}"
 
 - name: Adding list domains as virtual domains
   blockinfile:
@@ -40,7 +40,7 @@
   with_items: "{{ mail_domains }}"
 
 - name: Compiling Sympa transport
-  shell: postmap /etc/postfix/domains.sympa
+  command: postmap /etc/postfix/domains.sympa
 
 - name: Adding required generic aliases
   blockinfile:
@@ -54,7 +54,7 @@
   with_items: "{{ mail_domains }}"
 
 - name: Compiling Sympa transport
-  shell: postmap /etc/postfix/virtual.sympa
+  command: postmap /etc/postfix/virtual.sympa
 
 - name: Adding required generic transports
   blockinfile:
@@ -70,7 +70,7 @@
   with_items: "{{ mail_domains }}"
 
 - name: Compiling Sympa transport
-  shell: postmap /etc/postfix/transport
+  command: postmap /etc/postfix/transport
 
 - name: Master.cf configuration
   blockinfile:

--- a/roles/sympa/tasks/sympa_startup.yml
+++ b/roles/sympa/tasks/sympa_startup.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Upgrade Sympa
-  shell: "{{ install_prefix }}/{{ sympa.install_dir_name }}/bin/sympa.pl --upgrade"
+  command: "{{ install_prefix }}/{{ sympa.install_dir_name }}/bin/sympa.pl --upgrade"
 
 - name: Create Sympa database for new installations
-  shell: "{{ install_prefix }}/{{ sympa.install_dir_name }}/bin/sympa.pl --health_check"
+  command: "{{ install_prefix }}/{{ sympa.install_dir_name }}/bin/sympa.pl --health_check"
 
 - name: Create systemd directory for custom conf
   file: dest=/etc/systemd/system/sympa.service.d state=directory mode=755

--- a/roles/sympa/tasks/sympa_web.yml
+++ b/roles/sympa/tasks/sympa_web.yml
@@ -1,12 +1,13 @@
 ---
-# Configure Apache
 
-- name: Install Apache2
-  apt: name={{ item }} state=present
-  with_items:
-  - apache2
-  - libapache2-mod-fcgid # FastCGI interface module for Apache 2
-  - spawn-fcgi
+- name: Installing Apache2
+  apt:
+    name: 
+      - apache2
+      - libapache2-mod-fcgid
+      - spawn-fcgi
+    state: present
+  tags: apache
 
 - name: ensure sockets directory
   file:

--- a/roles/sympa/tasks/sympa_web.yml
+++ b/roles/sympa/tasks/sympa_web.yml
@@ -9,13 +9,6 @@
     state: present
   tags: apache
 
-- name: ensure sockets directory
-  file:
-    dest: "/var/run/sympa"
-    state: directory
-    mode: 0755
-  tags: apache
-
 - name: install wwsympa service config
   template: src=fcgi/wwsympa.service.j2 dest=/lib/systemd/system/wwsympa.service
   tags: apache

--- a/roles/sympa/tasks/sympa_web.yml
+++ b/roles/sympa/tasks/sympa_web.yml
@@ -2,26 +2,71 @@
 # Configure Apache
 
 - name: Install Apache2
-  apt:
-    name:
-      - apache2
-      - libapache2-mod-fcgid # FastCGI interface module for Apache 2
-    state: present
+  apt: name={{ item }} state=present
+  with_items:
+  - apache2
+  - libapache2-mod-fcgid # FastCGI interface module for Apache 2
+  - spawn-fcgi
 
-- name: Enable CGI Apache module
-  apache2_module: name=fcgid state=present
-  notify: Restart Apache
+- name: ensure sockets directory
+  file:
+    dest: "/var/run/sympa"
+    state: directory
+    mode: 0755
   tags: apache
- 
-- name: install custom fcgid.conf file
-  template: src=apache/fcgid.conf.j2 dest=/etc/apache2/mods-available/fcgid.conf
-  notify: Restart Apache
+
+- name: install wwsympa service config
+  template: src=fcgi/wwsympa.service.j2 dest=/lib/systemd/system/wwsympa.service
+  notify: restart systemd
+  tags: apache
+
+- name: start wwsympa
+  shell: "systemctl start wwsympa.service"
+  tags: apache
+
+- name: setup autostart for wwsympa
+  shell: "systemctl enable wwsympa.service"
+  tags: apache
+
+- name: install sympasoap service config
+  template: src=fcgi/sympasoap.service.j2 dest=/lib/systemd/system/sympasoap.service
+  notify: restart systemd
+  tags: apache
+
+- name: start sympasoap
+  shell: "systemctl start sympasoap.service"
+  tags: apache
+
+- name: setup autostart for sympasoap
+  shell: "systemctl enable sympasoap.service"
   tags: apache
 
 - name: Install Sympa web config
   template: src=apache/sympa_web.conf.j2 dest=/etc/apache2/conf-available/sympa.conf
-  notify: Restart Apache
+  notify: restart apache
   tags: apache
+
+- name: Enable mod_rewrite
+  shell: a2enmod proxy_fcgi
+  notify: restart apache
 
 - name: Enable Sympa web config
   shell: a2enconf sympa
+  notify: restart apache
+
+- name: Enable mod_rewrite
+  shell: a2enmod rewrite
+  notify: restart apache
+
+- name: Add redirect from / to /sympa
+  tags: apache
+  blockinfile:
+    state: present
+    marker: "# {mark} ANSIBLE MANAGED {{ item }} redirect to /sympa"
+    path: "/etc/apache2/sites-available/{{ item }}.conf"
+    block: |
+      RewriteEngine On
+      RewriteRule ^/?$ https://%{SERVER_NAME}/sympa [QSA,R=301,L]
+  notify: restart apache
+  with_items: "{{ web_domains }}"
+

--- a/roles/sympa/tasks/sympa_web.yml
+++ b/roles/sympa/tasks/sympa_web.yml
@@ -39,15 +39,15 @@
   tags: apache
 
 - name: Enable mod_rewrite
-  shell: a2enmod proxy_fcgi
+  command: a2enmod proxy_fcgi
   notify: restart apache
 
 - name: Enable Sympa web config
-  shell: a2enconf sympa
+  command: a2enconf sympa
   notify: restart apache
 
 - name: Enable mod_rewrite
-  shell: a2enmod rewrite
+  command: a2enmod rewrite
   notify: restart apache
 
 - name: Add redirect from / to /sympa

--- a/roles/sympa/tasks/sympa_web.yml
+++ b/roles/sympa/tasks/sympa_web.yml
@@ -18,28 +18,26 @@
 
 - name: install wwsympa service config
   template: src=fcgi/wwsympa.service.j2 dest=/lib/systemd/system/wwsympa.service
-  notify: restart systemd
   tags: apache
 
 - name: start wwsympa
-  shell: "systemctl start wwsympa.service"
-  tags: apache
-
-- name: setup autostart for wwsympa
-  shell: "systemctl enable wwsympa.service"
+  systemd:
+    state: started
+    name: wwsympa
+    enabled: yes
+    daemon_reload: yes
   tags: apache
 
 - name: install sympasoap service config
   template: src=fcgi/sympasoap.service.j2 dest=/lib/systemd/system/sympasoap.service
-  notify: restart systemd
   tags: apache
 
 - name: start sympasoap
-  shell: "systemctl start sympasoap.service"
-  tags: apache
-
-- name: setup autostart for sympasoap
-  shell: "systemctl enable sympasoap.service"
+  systemd:
+    state: started
+    name: sympasoap
+    enabled: yes
+    daemon_reload: yes
   tags: apache
 
 - name: Install Sympa web config

--- a/roles/sympa/tasks/sympa_web.yml
+++ b/roles/sympa/tasks/sympa_web.yml
@@ -35,20 +35,20 @@
 
 - name: Install Sympa web config
   template: src=apache/sympa_web.conf.j2 dest=/etc/apache2/conf-available/sympa.conf
-  notify: restart apache
+  notify: Restart Apache
   tags: apache
 
 - name: Enable mod_rewrite
   command: a2enmod proxy_fcgi
-  notify: restart apache
+  notify: Restart Apache
 
 - name: Enable Sympa web config
   command: a2enconf sympa
-  notify: restart apache
+  notify: Restart Apache
 
 - name: Enable mod_rewrite
   command: a2enmod rewrite
-  notify: restart apache
+  notify: Restart Apache
 
 - name: Add redirect from / to /sympa
   tags: apache
@@ -59,6 +59,6 @@
     block: |
       RewriteEngine On
       RewriteRule ^/?$ https://%{SERVER_NAME}/sympa [QSA,R=301,L]
-  notify: restart apache
+  notify: Restart Apache
   with_items: "{{ web_domains }}"
 

--- a/roles/sympa/templates/apache/sympa_web.conf.j2
+++ b/roles/sympa/templates/apache/sympa_web.conf.j2
@@ -9,11 +9,11 @@
   </Location>
 
   <Location /sympa>
-    SetHandler "proxy:unix:/var/run/sympa/wwsympa.socket|fcgi://localhost"
+    SetHandler "proxy:unix:/var/run/wwsympa/wwsympa.socket|fcgi://localhost"
     Require all granted
   </Location>
 
   <Location /sympasoap>
-    SetHandler "proxy:unix:/var/run/sympa/sympasoap.socket|fcgi://localhost"
+    SetHandler "proxy:unix:/var/run/sympasoap/sympasoap.socket|fcgi://localhost"
     Require all granted
   </Location>

--- a/roles/sympa/templates/apache/sympa_web.conf.j2
+++ b/roles/sympa/templates/apache/sympa_web.conf.j2
@@ -9,14 +9,11 @@
   </Location>
 
   <Location /sympa>
-    SetHandler fcgid-script
+    SetHandler "proxy:unix:/var/run/sympa/wwsympa.socket|fcgi://localhost"
     Require all granted
   </Location>
-  
+
   <Location /sympasoap>
-    SetHandler fcgid-script
+    SetHandler "proxy:unix:/var/run/sympa/sympasoap.socket|fcgi://localhost"
     Require all granted
   </Location>
-  
-  ScriptAlias /sympa {{ install_prefix }}/{{ sympa.install_dir_name }}/bin/wwsympa-wrapper.fcgi
-  ScriptAlias /sympasoap {{ install_prefix }}/{{ sympa.install_dir_name }}/bin/sympa_soap_server-wrapper.fcgi

--- a/roles/sympa/templates/fcgi/sympasoap.service.j2
+++ b/roles/sympa/templates/fcgi/sympasoap.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=SympaSOAP - SOAP interface for Sympa mailing list manager
+After=syslog.target
+BindTo=sympa.service
+ 
+[Service]
+Type=forking
+PIDFile=/var/run/sympa/sympasoap.pid
+ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
+    -P /var/run/sympa/sympasoap.pid \
+    -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
+    {{ install_prefix }}/{{ sympa.install_dir_name }}/bin/sympa_soap_server.fcgi
+Environment="FCGI_CHILDREN=5"
+Environment="FCGI_USER=sympa"
+Environment="FCGI_GROUP=sympa"
+Environment="FCGI_OPTS=-s /var/run/sympa/sympasoap.socket -M 0644 -U www-data"
+EnvironmentFile=-/etc/sysconfig/sympa
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/sympa/templates/fcgi/sympasoap.service.j2
+++ b/roles/sympa/templates/fcgi/sympasoap.service.j2
@@ -5,17 +5,17 @@ BindTo=sympa.service
  
 [Service]
 Type=forking
-PIDFile=/var/run/sympa/sympasoap.pid
+PIDFile=/var/run/sympasoap/sympasoap.pid
 ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
-    -P /var/run/sympa/sympasoap.pid \
+    -P /var/run/sympasoap/sympasoap.pid \
     -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
     {{ install_prefix }}/{{ sympa.install_dir_name }}/bin/sympa_soap_server.fcgi
 Environment="FCGI_CHILDREN=5"
 Environment="FCGI_USER=sympa"
 Environment="FCGI_GROUP=sympa"
-Environment="FCGI_OPTS=-s /var/run/sympa/sympasoap.socket -M 0644 -U www-data"
+Environment="FCGI_OPTS=-s /var/run/sympasoap/sympasoap.socket -M 0644 -U www-data"
 EnvironmentFile=-/etc/sysconfig/sympa
-RuntimeDirectory=sympa
+RuntimeDirectory=sympasoap
 RuntimeDirectoryPreserve=yes
 Restart=always
 

--- a/roles/sympa/templates/fcgi/sympasoap.service.j2
+++ b/roles/sympa/templates/fcgi/sympasoap.service.j2
@@ -15,6 +15,8 @@ Environment="FCGI_USER=sympa"
 Environment="FCGI_GROUP=sympa"
 Environment="FCGI_OPTS=-s /var/run/sympa/sympasoap.socket -M 0644 -U www-data"
 EnvironmentFile=-/etc/sysconfig/sympa
+RuntimeDirectory=sympa
+RuntimeDirectoryPreserve=yes
 Restart=always
 
 [Install]

--- a/roles/sympa/templates/fcgi/wwsympa.service.j2
+++ b/roles/sympa/templates/fcgi/wwsympa.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=WWSympa - Web interface for Sympa mailing list manager
+After=syslog.target
+BindTo=sympa.service
+ 
+[Service]
+Type=forking
+PIDFile=/var/run/sympa/wwsympa.pid
+ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
+    -P /var/run/sympa/wwsympa.pid \
+    -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
+    {{ install_prefix }}/{{ sympa.install_dir_name }}/bin/wwsympa.fcgi
+Environment="FCGI_CHILDREN=5"
+Environment="FCGI_USER=sympa"
+Environment="FCGI_GROUP=sympa"
+Environment="FCGI_OPTS=-s /var/run/sympa/wwsympa.socket -M 0644 -U www-data"
+EnvironmentFile=-/etc/sysconfig/sympa
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/sympa/templates/fcgi/wwsympa.service.j2
+++ b/roles/sympa/templates/fcgi/wwsympa.service.j2
@@ -15,6 +15,8 @@ Environment="FCGI_USER=sympa"
 Environment="FCGI_GROUP=sympa"
 Environment="FCGI_OPTS=-s /var/run/sympa/wwsympa.socket -M 0644 -U www-data"
 EnvironmentFile=-/etc/sysconfig/sympa
+RuntimeDirectory=sympa
+RuntimeDirectoryPreserve=yes
 Restart=always
 
 [Install]

--- a/roles/sympa/templates/fcgi/wwsympa.service.j2
+++ b/roles/sympa/templates/fcgi/wwsympa.service.j2
@@ -5,17 +5,17 @@ BindTo=sympa.service
  
 [Service]
 Type=forking
-PIDFile=/var/run/sympa/wwsympa.pid
+PIDFile=/var/run/wwsympa/wwsympa.pid
 ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
-    -P /var/run/sympa/wwsympa.pid \
+    -P /var/run/wwsympa/wwsympa.pid \
     -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
     {{ install_prefix }}/{{ sympa.install_dir_name }}/bin/wwsympa.fcgi
 Environment="FCGI_CHILDREN=5"
 Environment="FCGI_USER=sympa"
 Environment="FCGI_GROUP=sympa"
-Environment="FCGI_OPTS=-s /var/run/sympa/wwsympa.socket -M 0644 -U www-data"
+Environment="FCGI_OPTS=-s /var/run/wwsympa/wwsympa.socket -M 0644 -U www-data"
 EnvironmentFile=-/etc/sysconfig/sympa
-RuntimeDirectory=sympa
+RuntimeDirectory=wwsympa
 RuntimeDirectoryPreserve=yes
 Restart=always
 


### PR DESCRIPTION
Now Sympa FCGI are linked to the web server using spawnfcgi, as recommended in the Sympa documentation: https://sympa-community.github.io/manual/install/configure-http-server-spawnfcgi.html

This prepares enabling nginx as spawnfcgi is also the recommended setting for Nginx.

EDIT: I forgot to mention: Currently, when you restart Apache, the Sympa fcgi won't restart, leaving some fcgi running not linked to an Apache process, so all request are lost until you explicitely kill the fcgi processes.
Changing the way the fcgi is run fixed this problem.