### PR TITLE
Remove first "vagrant provision" from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ Create the new environment for the VM:
 
     $ ./scripts/create_new_environment.sh environments/local
 
-Provision the environment:
-
-    $ vagrant provision
-
 And link the inventory to your local directory:
 
     $ ln -s ../../.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory environments/local/inventory


### PR DESCRIPTION
It will be run either by "vagrant up" or after creating the environment.