### PR TITLE
Fix selection of database type

### DIFF
--- a/roles/sympa/tasks/main.yml
+++ b/roles/sympa/tasks/main.yml
@@ -50,7 +50,7 @@
   
 - name: Install and configure database
   tags: sympa_db
-  import_tasks: "sympa_db_{{ sympa.db.type | lower }}.yml"
+  include_tasks: "sympa_db_{{ sympa.db.type | lower }}.yml"
 
 - name: Getting source folder name
   tags: always


### PR DESCRIPTION
We need to use include_tasks as task file is determined dynamically.
Otherwise it will pick "mysql", even when "Pg" is specified as database type in the environment.

Sorry to say, but that is another bad and unnecessary change from refactoring. :-1: 