### PR TITLE
Remove voot_feature configuration setting.

### DIFF
--- a/roles/sympa/templates/sympa.conf.j2
+++ b/roles/sympa/templates/sympa.conf.j2
@@ -38,8 +38,6 @@ soap_url	https://{{ common.web.domain }}/sympasoap
 ## This setting can be overridden by each list
 process_archive	on
 
-voot_feature	off
-
 max_wrong_password	19
 
 ## Directory for storing static contents (CSS, members pictures,


### PR DESCRIPTION
This causes startup error with recent Sympa release.
