### PR TITLE
Switch to Python 2.7 in Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: xenial
 sudo: required
 language: python
+python: 2.7
 before_install:
   - sudo apt-add-repository -y ppa:ansible/ansible
   - sudo apt-get update


### PR DESCRIPTION
Keyczar doesn't work with Python 3.6.