### PR TITLE
Improve task for creating Sympa log file.

### DIFF
--- a/roles/sympa/tasks/sympa_install/post_install.yml
+++ b/roles/sympa/tasks/sympa_install/post_install.yml
@@ -6,7 +6,7 @@
   notify: restart sympa
   
 - name: Create sympa log file
-  file: dest=/var/log/sympa state=touch mode=622 owner=syslog group=adm
+  file: dest=/var/log/sympa.log state=touch mode=0640 owner=sympa group=adm
   tags: syslog
   
 - name: Install custom rsyslog conf file

--- a/roles/sympa/tasks/sympa_install/post_install.yml
+++ b/roles/sympa/tasks/sympa_install/post_install.yml
@@ -6,7 +6,7 @@
   notify: restart sympa
   
 - name: Create sympa log file
-  file: dest=/var/log/sympa.log state=touch mode=0640 owner=sympa group=adm
+  file: dest=/var/log/sympa.log state=touch mode=0660 owner=sympa group=adm
   tags: syslog
   
 - name: Install custom rsyslog conf file

--- a/roles/sympa/templates/logrotate/sympa.j2
+++ b/roles/sympa/templates/logrotate/sympa.j2
@@ -7,7 +7,7 @@
        compress
        delaycompress
 	   copytruncate
-	   create 640 sympa adm
+	   create 660 sympa adm
        postrotate
                invoke-rc.d --quiet sympa reload > /dev/null
                invoke-rc.d --quiet rsyslog reload > /dev/null || true

--- a/roles/sympa/templates/logrotate/sympa.j2
+++ b/roles/sympa/templates/logrotate/sympa.j2
@@ -1,5 +1,5 @@
 # Conf for sympa log files rotation
-/var/log/sympa {
+/var/log/sympa.log {
        missingok
 	   weekly
        notifempty
@@ -7,7 +7,7 @@
        compress
        delaycompress
 	   copytruncate
-	   create 640 root adm
+	   create 640 sympa adm
        postrotate
                invoke-rc.d --quiet sympa reload > /dev/null
                invoke-rc.d --quiet rsyslog reload > /dev/null || true

--- a/roles/sympa/templates/rsyslog/sympa.conf.j2
+++ b/roles/sympa/templates/rsyslog/sympa.conf.j2
@@ -1,1 +1,1 @@
-local1.*       /var/log/sympa
+local1.*       /var/log/sympa.log


### PR DESCRIPTION
Fix weird permission value missing the leading zero.
Change owner to sympa which makes more sense, also syslog user doesn't exist on Debian.
Use .log suffix to align filename with Debian package and common practices.