### PR TITLE
Use false as default for set_hostname and set_hosts variables.

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -12,11 +12,11 @@
 
 - name: Setting false flag for proxy settings
   set_fact:
-    proxy: 0
+    proxy: false
 
 - name: Setting flag for proxy settings
   set_fact:
-    proxy: 1
+    proxy: true
   tags: proxy
   when: inventory_hostname == 'local-proxy'
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -11,9 +11,9 @@ users:
       password: no
       group: sympa
       
-set_hostname: 0
+set_hostname: false
 
-set_hosts: 0
+set_hosts: false
 
 ## This variable should be populated this way:
 ## public_keys:


### PR DESCRIPTION
This prevents the following deprecation warning:

evaluating 0 as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future.