### PR TITLE
Fix template for iptable rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ For now, only Apache is configured.
 
   - `common.mail.domain`: mail domain (overriden by vhosts configuration)
   - `common.mail.force_smtp_route`: if set to 1, any outgoing SMTP session will be made towards `common.mail.outgoing_server` without DNS resolution.
-  - `common.mail.incoming_smtp`: the IP from which incoming mail should come to the server. Leave blak if you accept any incoming server.
+  - `common.mail.incoming_smtp`: the IP from which incoming mail should come to the server. Remove variable to accept any incoming server.
   - `common.mail.outgoing_server`: See `common.mail.force_smtp_route`.
   - `common.mail.enable_check_smtp`: Optional activation of a program sending mails to check whether mails arrive or not.
 

--- a/environments/template/templates/common/rules.v4.j2
+++ b/environments/template/templates/common/rules.v4.j2
@@ -25,7 +25,7 @@
 
 {% if 'postfix' in group_names %}
 # registry server
--A INPUT -p tcp --dport 25 -s {{ mail.incoming_smtp }} -m state --state NEW -j ACCEPT
+-A INPUT -p tcp --dport 25 {% if 'incoming_smtp' in mail %}-s {{ mail.incoming_smtp }} {% endif %}-m state --state NEW -j ACCEPT
 {% endif %}
 -A INPUT -p tcp --dport 443 -m state --state NEW -j ACCEPT
 -A INPUT -p tcp --dport 80 -m state --state NEW -j ACCEPT


### PR DESCRIPTION
It currently produces invalid rules when incoming_smtp is not set.