### PR TITLE
Using tests as filters is deprecated

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -12,7 +12,7 @@
   tasks:
     - name: Check Ansible version
       assert:
-        that: "ansible_version.full | version_compare('2.5.0', '>=')"
+        that: "ansible_version.full is version_compare('2.5.0', '>=')"
         msg: "This playbook requires Ansible 2.5.0 or greater."
 
 - name: Get Jinja2 version


### PR DESCRIPTION
This causes failure of the "Check Ansible version" task with Ansible 2.9