### PR TITLE
Fix redirect from / to /sympa

### DIFF
--- a/roles/apache/templates/apache_vhost.conf.j2
+++ b/roles/apache/templates/apache_vhost.conf.j2
@@ -12,6 +12,9 @@
     ServerName {{ item.web.domain }}
     ServerSignature off
 
+    RewriteEngine On
+    RewriteRule ^/?$ https://%{SERVER_NAME}/sympa [QSA,R=301,L]
+
     ErrorLog ${APACHE_LOG_DIR}/error_{{ item.web.domain }}.log
     CustomLog ${APACHE_LOG_DIR}/access_{{ item.web.domain }}.log combined
 

--- a/roles/sympa/tasks/sympa_web.yml
+++ b/roles/sympa/tasks/sympa_web.yml
@@ -60,15 +60,3 @@
   command: a2enmod rewrite
   notify: Restart Apache
 
-- name: Add redirect from / to /sympa
-  tags: apache
-  blockinfile:
-    state: present
-    marker: "# {mark} ANSIBLE MANAGED {{ item }} redirect to /sympa"
-    path: "/etc/apache2/sites-available/{{ item }}.conf"
-    block: |
-      RewriteEngine On
-      RewriteRule ^/?$ https://%{SERVER_NAME}/sympa [QSA,R=301,L]
-  notify: Restart Apache
-  with_items: "{{ web_domains }}"
-


### PR DESCRIPTION
Currently it doesn't work at all. Also it changes the same files twice by
different tasks which is a really bad idea.

Tested with the following task:

```

- name: Test redirection of / to /sympa
  uri:
    url: "https://{{ item.web.domain }}"
    validate_certs: no
  with_items: "{{ apache_vhosts }}"
  register: sympa_test_redirection
  failed_when: not sympa_test_redirection.redirected or sympa_test_redirection.url != "https://{{ item.web.domain }}/sympa"   
```