### PR TITLE
Remove unsupported executable parameter from command task

### DIFF
--- a/roles/sympa/tasks/sympa_install/get_sources_from_repo.yml
+++ b/roles/sympa/tasks/sympa_install/get_sources_from_repo.yml
@@ -16,5 +16,4 @@
   command: autoreconf -i
   args:
     chdir: "{{ install_prefix }}/{{ sympa.install_dir_name }}/src/{{ source_dir }}"
-    executable: /bin/bash
 


### PR DESCRIPTION
Quells  the following warning:

```
[WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
```